### PR TITLE
Misc improvements :

### DIFF
--- a/examples/ESP_spiram/ESP_spiram.ino
+++ b/examples/ESP_spiram/ESP_spiram.ino
@@ -10,12 +10,14 @@
 #include <SPI.h>
 #include <ESP8266Spiram.h>
 
+ESP8266Spiram Spiram;
+
+
 void setup() {
   Serial.begin(115200);
   delay(1000);
   Spiram.begin();
 }
-
 
 
 void loop() {

--- a/src/ESP8266Spiram.cpp
+++ b/src/ESP8266Spiram.cpp
@@ -28,7 +28,7 @@ ESP8266Spiram Spiram;
 
 // setup of C/S line as per HSPI default
 ESP8266Spiram::ESP8266Spiram() {
-      Cs=15; // default values
+      Cs=15; // default value for HSPI port
       clkSpeed=20e6; // The 23LC1024 supports theorically up to 20MHz
 }
 

--- a/src/ESP8266Spiram.cpp
+++ b/src/ESP8266Spiram.cpp
@@ -28,7 +28,8 @@ ESP8266Spiram Spiram;
 
 // setup of C/S line as per HSPI default
 ESP8266Spiram::ESP8266Spiram() {
-      Cs=15; // default value
+      Cs=15; // default values
+      clkSpeed=20e6; // The 23LC1024 supports theorically up to 20MHz
 }
 
 
@@ -237,7 +238,7 @@ uint8_t ESP8266Spiram::getMode(void){
 }
 
 void ESP8266Spiram::beginTrans_(void){
-        SPI.beginTransaction(SPISettings(20000000, MSBFIRST, SPI_MODE0));
+        SPI.beginTransaction(SPISettings(clkSpeed, MSBFIRST, SPI_MODE0));
         digitalWrite(Cs, LOW);
 }
 
@@ -248,4 +249,8 @@ void ESP8266Spiram::endTrans_(void){
 
 void ESP8266Spiram::setCsPin(int csPin) {
         Cs = csPin;
+}
+
+void ESP8266Spiram::setClkSpeed(uint32_t speed) {
+        clkSpeed = speed;
 }

--- a/src/ESP8266Spiram.cpp
+++ b/src/ESP8266Spiram.cpp
@@ -32,6 +32,10 @@ ESP8266Spiram::ESP8266Spiram() {
       clkSpeed=20e6; // The 23LC1024 supports theorically up to 20MHz
 }
 
+ESP8266Spiram::ESP8266Spiram(int cs, int clockspeedhz) {
+      Cs = cs;
+      clkSpeed = clockspeedhz;
+}
 
 // Activate the library setting up ByteMode of operation (see 2.2 pg.5)
 void ESP8266Spiram::begin(void)	{
@@ -245,12 +249,4 @@ void ESP8266Spiram::beginTrans_(void){
 void ESP8266Spiram::endTrans_(void){
         digitalWrite(Cs, HIGH);
         SPI.endTransaction();  
-}
-
-void ESP8266Spiram::setCsPin(int csPin) {
-        Cs = csPin;
-}
-
-void ESP8266Spiram::setClkSpeed(uint32_t speed) {
-        clkSpeed = speed;
 }

--- a/src/ESP8266Spiram.h
+++ b/src/ESP8266Spiram.h
@@ -44,14 +44,13 @@ class ESP8266Spiram
 {
   public:
     ESP8266Spiram();
+    ESP8266Spiram(int cs, int clockspeedhz);
     void begin(void);
     void write(uint32_t addr, uint8_t *buff, int len);
     void read(uint32_t addr, uint8_t *buff, int len);
     void setByteMode(void);
     void setPageMode(void);
     void setSeqMode(void);
-    void setCsPin(int csPin);
-    void setClkSpeed(uint32_t speed);
     uint8_t getMode();
   private:
     void beginTrans_(void);

--- a/src/ESP8266Spiram.h
+++ b/src/ESP8266Spiram.h
@@ -51,6 +51,7 @@ class ESP8266Spiram
     void setPageMode(void);
     void setSeqMode(void);
     void setCsPin(int csPin);
+    void setClkSpeed(uint32_t speed);
     uint8_t getMode();
   private:
     void beginTrans_(void);
@@ -62,6 +63,7 @@ class ESP8266Spiram
     void writeSeq(uint32_t addr, uint8_t *buff, int len);
     void reset_();
     int Cs;
+    uint32_t clkSpeed;
     uint8_t opMode;
     uint8_t readReg_(void);
     uint8_t transfer8(uint8_t data);

--- a/src/ESP8266Spiram.h
+++ b/src/ESP8266Spiram.h
@@ -50,13 +50,19 @@ class ESP8266Spiram
     void setByteMode(void);
     void setPageMode(void);
     void setSeqMode(void);
+    void setCsPin(int csPin);
     uint8_t getMode();
   private:
     void beginTrans_(void);
     void endTrans_(void);
     void writeReg_(uint8_t reg);
+    void readBytes(uint32_t addr, uint8_t *buff, int len);
+    void readSeq(uint32_t addr, uint8_t *buff, int len);
+    void writeBytes(uint32_t addr, uint8_t *buff, int len);
+    void writeSeq(uint32_t addr, uint8_t *buff, int len);
     void reset_();
     int Cs;
+    uint8_t opMode;
     uint8_t readReg_(void);
     uint8_t transfer8(uint8_t data);
   	uint16_t transfer16(uint16_t data);


### PR DESCRIPTION
- Ability to set Chip Select pin : function to call before begin: setCsPin(<gpio number>).
- read / write functions adapted to selected mode (sequential or byte mode), to improve speed
- When changing mode, re-read the chip mode to be synced.

Example of usage:

```
ESP8266Spiram Spiram;
Spiram.setCsPin(4);  //Chip select pin is on GPIO4
Spiram.begin();
Spiram.setSeqMode();
```


Signed-off-by: Sebastien Decourriere <sebtx452@gmail.com>